### PR TITLE
Skip checking multiscales if parent store not found

### DIFF
--- a/funlib/persistence/arrays/datasets.py
+++ b/funlib/persistence/arrays/datasets.py
@@ -238,10 +238,10 @@ def _read_attrs(ds, order="C"):
 
     # check recursively for multiscales attribute in the zarr store tree
     try:
-    	multiscales, multiscale_group = check_for_multiscale(group=access_parent(ds))
+        multiscales, multiscale_group = check_for_multiscale(group=access_parent(ds))
     # Ignore if parent group not found - likely a newly created store
     except GroupNotFoundError as e:
-        multiscales = None 
+        multiscales = None
 
     # check for attributes in .zarr group multiscale
     if not isinstance(ds.store, (zarr.n5.N5Store, zarr.n5.N5FSStore)):

--- a/funlib/persistence/arrays/datasets.py
+++ b/funlib/persistence/arrays/datasets.py
@@ -4,6 +4,7 @@ from funlib.geometry import Coordinate, Roi
 
 import zarr
 from zarr.n5 import N5FSStore
+from zarr.errors import GroupNotFoundError
 import h5py
 import json
 import logging
@@ -236,7 +237,11 @@ def _read_attrs(ds, order="C"):
         )
 
     # check recursively for multiscales attribute in the zarr store tree
-    multiscales, multiscale_group = check_for_multiscale(group=access_parent(ds))
+    try:
+    	multiscales, multiscale_group = check_for_multiscale(group=access_parent(ds))
+    # Ignore if parent group not found - likely a newly created store
+    except GroupNotFoundError as e:
+        multiscales = None 
 
     # check for attributes in .zarr group multiscale
     if not isinstance(ds.store, (zarr.n5.N5Store, zarr.n5.N5FSStore)):


### PR DESCRIPTION
Ran into an issue in dacapo where during validation (during/after training), a newly created validation store would crash the validation worker due to the `check_for_multiscale` function looking for a parent group of a store that hasn't been initialized yet with array data.

This fix is a bit of a monkey-patch but hopefully the specific error catch will just touch this one issue and nothing else.

If there is a better way to address this lmk and I can think about a less patch-y fix to this issue.