### PR TITLE
Lazy roi slicing

### DIFF
--- a/funlib/persistence/arrays/array.py
+++ b/funlib/persistence/arrays/array.py
@@ -247,7 +247,10 @@ class Array(Freezable):
     @property
     def is_writeable(self):
         return len(self.lazy_ops) == 0 or all(
-            [self._is_slice(lazy_op, writeable=True) for lazy_op in self.lazy_ops]
+            [
+                self._is_slice(lazy_op, writeable=True) or isinstance(lazy_op, Roi)
+                for lazy_op in self.lazy_ops
+            ]
         )
 
     def apply_lazy_ops(self, lazy_op):

--- a/funlib/persistence/arrays/array.py
+++ b/funlib/persistence/arrays/array.py
@@ -156,11 +156,10 @@ class Array(Freezable):
     @property
     def offset(self) -> Coordinate:
         """Get the offset of this array in world units."""
-        udims = self.uncollapsed_dims(physical=True)
         return Coordinate(
             [
                 self._metadata.offset[ii]
-                for ii, uncollapsed in enumerate(udims)
+                for ii, uncollapsed in enumerate(self.uncollapsed_dims(physical=True))
                 if uncollapsed
             ]
         )
@@ -168,21 +167,19 @@ class Array(Freezable):
     @property
     def voxel_size(self) -> Coordinate:
         """Get the size of a voxel in world units."""
-        udims = self.uncollapsed_dims(physical=True)
         return Coordinate(
             [
                 self._metadata.voxel_size[ii]
-                for ii, uncollapsed in enumerate(udims)
+                for ii, uncollapsed in enumerate(self.uncollapsed_dims(physical=True))
                 if uncollapsed
             ]
         )
 
     @property
     def units(self) -> list[str]:
-        udims = self.uncollapsed_dims(physical=True)
         return [
             self._metadata.units[ii]
-            for ii, uncollapsed in enumerate(udims)
+            for ii, uncollapsed in enumerate(self.uncollapsed_dims(physical=True))
             if uncollapsed
         ]
 
@@ -205,11 +202,9 @@ class Array(Freezable):
     @property
     def physical_shape(self):
         return tuple(
-            self._source_data.shape[ii]
-            for ii, (uncollapsed, type) in enumerate(
-                zip(self.uncollapsed_dims(physical=False), self._metadata.types)
-            )
-            if uncollapsed and type in ["space", "time"]
+            self.data.shape[ii]
+            for ii, axis_type in enumerate(self.types)
+            if axis_type in ["space", "time"]
         )
 
     @property

--- a/funlib/persistence/arrays/lazy_ops.py
+++ b/funlib/persistence/arrays/lazy_ops.py
@@ -1,3 +1,4 @@
 from typing import Callable, Union
+from funlib.geometry import Roi
 
-LazyOp = Union[slice, Callable]
+LazyOp = Union[slice, Callable, Roi]

--- a/funlib/persistence/arrays/lazy_ops.py
+++ b/funlib/persistence/arrays/lazy_ops.py
@@ -1,4 +1,5 @@
 from typing import Callable, Union
+
 from funlib.geometry import Roi
 
 LazyOp = Union[slice, Callable, Roi]

--- a/funlib/persistence/arrays/utils.py
+++ b/funlib/persistence/arrays/utils.py
@@ -2,7 +2,6 @@ from collections.abc import Sequence
 
 
 def interleave(a: Sequence, b: Sequence, choices: Sequence[bool]) -> list:
-    print(a, b, choices)
     a_ind = iter(range(len([c for c in choices if c])))
     b_ind = iter(range(len([c for c in choices if not c])))
     return [a[next(a_ind)] if c else b[next(b_ind)] for c in choices]

--- a/funlib/persistence/arrays/utils.py
+++ b/funlib/persistence/arrays/utils.py
@@ -1,0 +1,8 @@
+from collections.abc import Sequence
+
+
+def interleave(a: Sequence, b: Sequence, choices: Sequence[bool]) -> list:
+    print(a, b, choices)
+    a_ind = iter(range(len([c for c in choices if c])))
+    b_ind = iter(range(len([c for c in choices if not c])))
+    return [a[next(a_ind)] if c else b[next(b_ind)] for c in choices]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,11 @@ keywords = []
 
 dependencies = [
     "zarr>=2,<3",
-    "iohub >= 0.2.0b0",
+    # ImportError: cannot import name 'cbuffer_sizes' from 'numcodecs.blosc'
+    # We can pin zarr to >2.18.7 but then we have to drop python 3.10
+    # pin numcodecs to avoid breaking change
+    "numcodecs<0.16.0",
+    "iohub>=0.2.0b0",
     "funlib.geometry>=0.3.0",
     "networkx>=3.0.0",
     "pymongo>=4.0.0",
@@ -57,8 +61,5 @@ explicit_package_bases = true
 
 # # module specific overrides
 [[tool.mypy.overrides]]
-module = [
-    "zarr.*",
-    "iohub.*",
-]
+module = ["zarr.*", "iohub.*"]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     # ImportError: cannot import name 'cbuffer_sizes' from 'numcodecs.blosc'
     # We can pin zarr to >2.18.7 but then we have to drop python 3.10
     # pin numcodecs to avoid breaking change
-    "numcodecs<0.16.0",
+    "numcodecs>0.13,<0.16.0",
     "iohub>=0.2.0b0",
     "funlib.geometry>=0.3.0",
     "networkx>=3.0.0",

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -371,7 +371,12 @@ def test_slicing_channel_dim_last():
 
 
 def test_lazy_op():
-    a = Array(np.arange(0, 4 * 4).reshape(4, 2, 2), (0, 0), (1, 1), types=["space", "channel", "time"])
+    a = Array(
+        np.arange(0, 4 * 4).reshape(4, 2, 2),
+        (0, 0),
+        (1, 1),
+        types=["space", "channel", "time"],
+    )
     assert a.roi == Roi((0, 0), (4, 2))
     assert a.shape == (4, 2, 2)
 
@@ -379,7 +384,7 @@ def test_lazy_op():
     assert a.roi == Roi((2, 0), (2, 2))
     assert a.shape == (2, 2, 2)
     assert a.axis_names == ["d0", "c0^", "d1"]
-    
+
     a.lazy_op(np.s_[:, 0, :])
     assert a.roi == Roi((2, 0), (2, 2))
     assert a.shape == (2, 2)

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -413,7 +413,7 @@ def test_writeable():
     assert a.axis_names == ["d0", "d1"]
     assert a.is_writeable
 
-    a.lazy_op(Roi((0,0),(2,2)))
+    a.lazy_op(Roi((0, 0), (2, 2)))
     assert a.shape == (2, 2)
     assert a.axis_names == ["d0", "d1"]
     assert a.is_writeable

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -397,3 +397,28 @@ def test_lazy_op():
     assert a.dtype == int
     a.lazy_op(lambda b: b > 2)
     assert a.dtype == bool
+
+
+def test_writeable():
+    a = Array(
+        np.arange(0, 4 * 4).reshape(4, 2, 2),
+        (0, 0),
+        (1, 1),
+        types=["space", "channel", "time"],
+    )
+    assert a.is_writeable
+
+    a.lazy_op(np.s_[0:3, 1, :])
+    assert a.shape == (3, 2)
+    assert a.axis_names == ["d0", "d1"]
+    assert a.is_writeable
+
+    a.lazy_op(Roi((0,0),(2,2)))
+    assert a.shape == (2, 2)
+    assert a.axis_names == ["d0", "d1"]
+    assert a.is_writeable
+
+    a.lazy_op(lambda b: b > 2)
+    assert a.shape == (2, 2)
+    assert a.axis_names == ["d0", "d1"]
+    assert not a.is_writeable

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -368,3 +368,27 @@ def test_slicing_channel_dim_last():
 
     with pytest.raises(RuntimeError):
         a[:, :] = np.array([42, 43, 44]).reshape(3, 1)
+
+
+def test_lazy_op():
+    a = Array(np.arange(0, 4 * 4).reshape(4, 2, 2), (0, 0), (1, 1), types=["space", "channel", "time"])
+    assert a.roi == Roi((0, 0), (4, 2))
+    assert a.shape == (4, 2, 2)
+
+    a.lazy_op(Roi((2, 0), (2, 2)))
+    assert a.roi == Roi((2, 0), (2, 2))
+    assert a.shape == (2, 2, 2)
+    assert a.axis_names == ["d0", "c0^", "d1"]
+    
+    a.lazy_op(np.s_[:, 0, :])
+    assert a.roi == Roi((2, 0), (2, 2))
+    assert a.shape == (2, 2)
+    assert a.axis_names == ["d0", "d1"]
+
+    a.lazy_op(Roi((2, 0), (1, 2)))
+    assert a.roi == Roi((2, 0), (1, 2))
+    assert a.shape == (1, 2)
+
+    assert a.dtype == int
+    a.lazy_op(lambda b: b > 2)
+    assert a.dtype == bool


### PR DESCRIPTION
Adds lazy `Roi` slicing.
Also fixed a bug where `array.physical_shape` would be in accurate after applying a lazy slice operation.