### PR TITLE
Patch 0.7.1

### DIFF
--- a/src/funlib/persistence/__init__.py
+++ b/src/funlib/persistence/__init__.py
@@ -1,4 +1,4 @@
 from .arrays import Array, open_ds, prepare_ds, open_ome_ds, prepare_ome_ds  # noqa
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 __version_info__ = tuple(int(i) for i in __version__.split("."))

--- a/src/funlib/persistence/arrays/datasets.py
+++ b/src/funlib/persistence/arrays/datasets.py
@@ -333,7 +333,7 @@ def prepare_ds(
         else:
             if mode == "w":
                 logger.info(
-                    "Existing dataset is compatible, but mode is 'w' and thus the existing dataset will be deleted.
+                    "Existing dataset is compatible, but mode is 'w' and thus the existing dataset will be deleted."
                 )
             else:
                 ds = zarr.open(store, mode=mode, **kwargs)


### PR DESCRIPTION
minor update.
- Adds support for defining the dask scheduler. This can be helpful for setting to serial execution when running in multithreaded context where you are already handling the parallelization of array access.
- improves error messages when datasets are incompatible